### PR TITLE
fix: update deprecated and later removed doctrine interface

### DIFF
--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YUMLMetadataGrapher.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YUMLMetadataGrapher.php
@@ -19,7 +19,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\AnnotationParser;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\ClassStore;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\ColorManager;

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YUMLMetadataGrapherInterface.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YUMLMetadataGrapherInterface.php
@@ -19,7 +19,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Interface of utility to generate yUML compatible strings from metadata graphs

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/AnnotationParser.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/AnnotationParser.php
@@ -20,7 +20,7 @@ namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use ReflectionClass;
 
 class AnnotationParser implements AnnotationParserInterface

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/AnnotationParserInterface.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/AnnotationParserInterface.php
@@ -18,7 +18,7 @@
  */
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 interface AnnotationParserInterface
 {

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ClassStore.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ClassStore.php
@@ -20,7 +20,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Utility to generate yUML compatible strings from metadata graphs

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ClassStoreInterface.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ClassStoreInterface.php
@@ -20,7 +20,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Utility to generate yUML compatible strings from metadata graphs

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ColorManager.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ColorManager.php
@@ -8,7 +8,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 class ColorManager implements ColorManagerInterface
 {

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ColorManagerInterface.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ColorManagerInterface.php
@@ -7,7 +7,7 @@
  */
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 interface ColorManagerInterface
 {

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/NotesManager.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/NotesManager.php
@@ -7,7 +7,7 @@
  */
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 class NotesManager implements NotesManagerInterface
 {

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/NotesManagerInterface.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/NotesManagerInterface.php
@@ -7,7 +7,7 @@
  */
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 interface NotesManagerInterface
 {

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\StringGenerator\FieldGeneratorHelper;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\StringGenerator\StringGeneratorHelper;

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator/FieldGeneratorHelper.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator/FieldGeneratorHelper.php
@@ -2,7 +2,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\StringGenerator;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 class FieldGeneratorHelper implements FieldGeneratorHelperInterface

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator/FieldGeneratorHelperInterface.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator/FieldGeneratorHelperInterface.php
@@ -2,7 +2,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\StringGenerator;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 interface FieldGeneratorHelperInterface
 {

--- a/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGeneratorInterface.php
+++ b/lib/Onurb/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGeneratorInterface.php
@@ -2,7 +2,7 @@
 
 namespace Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\StringGenerator\VisitedAssociationLoggerInterface;
 
 interface StringGeneratorInterface

--- a/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YUMLMetadataGrapherTest.php
+++ b/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YUMLMetadataGrapherTest.php
@@ -19,7 +19,7 @@
 
 namespace OnurbTest\Doctrine\ORMMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Onurb\Doctrine\ORMMetadataGrapher\YUMLMetadataGrapher;
 use PHPUnit\Framework\TestCase;
 
@@ -65,7 +65,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawSimpleEntity()
     {
-        $class = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -78,7 +78,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawSimpleEntityWithFields()
     {
-        $class = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class->expects($this->any())->method('getFieldNames')->will($this->returnValue(array('a', 'b', 'c')));
         $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -98,7 +98,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawOneToOneUniDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -132,7 +132,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
@@ -145,7 +145,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawOneToOneBiDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -178,7 +178,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -219,7 +219,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawOneToOneBiDirectionalInverseAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -253,7 +253,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -293,7 +293,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawOneToManyBiDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -325,7 +325,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -366,7 +366,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawOneToManyBiDirectionalInverseAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -398,7 +398,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -439,7 +439,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawManyToManyUniDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -472,7 +472,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
@@ -485,12 +485,12 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawManyToManyUniDirectionalInverseAssociation()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -531,7 +531,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawManyToManyBiDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -563,7 +563,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -604,7 +604,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawManyToManyBiDirectionalInverseAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -637,7 +637,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -677,7 +677,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawManyToManyAssociationWithoutKnownInverseSide()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -718,7 +718,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawInheritance()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getName')
@@ -726,7 +726,7 @@ class YUMLMetadataGrapherTest extends TestCase
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\A'
             ));
 
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class2->expects($this->any())->method('getName')
@@ -745,7 +745,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawInheritanceWithParentsTree()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\E'
@@ -761,7 +761,7 @@ class YUMLMetadataGrapherTest extends TestCase
             )
         );
 
-        $classParent = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $classParent = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $classParent->expects($this->any())->method('getName')->will($this->returnValue(
             'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\D'
         ));
@@ -769,7 +769,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $classParent->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $classParent->expects($this->any())->method('isIdentifier')->will($this->returnValue(false));
 
-        $classOlderParent = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $classOlderParent = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $classOlderParent->expects($this->any())->method('getName')->will($this->returnValue(
             'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\A'
         ));
@@ -791,8 +791,8 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawInheritedFields()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
 
         $class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
@@ -821,10 +821,10 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawInheritedAssociations()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
-        $class3 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
-        $class4 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
+        $class3 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
+        $class4 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
 
         $class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
@@ -903,7 +903,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function injectMultipleRelationsWithBothBiAndMonoDirectional()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -935,7 +935,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -967,7 +967,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class3 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class3 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -1025,7 +1025,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function injectTwoClassesWithTwoDifferentRelationsOneToManyBidirectionnal()
     {
-        $classAB = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $classAB = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -1064,7 +1064,7 @@ class YUMLMetadataGrapherTest extends TestCase
         $classAB->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $classAB->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $classCD = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $classCD = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -1191,7 +1191,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawWithColorsAdded()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -1211,7 +1211,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawWithColorsAddedOnParentNamespace()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -1231,7 +1231,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawColorPriority()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -1252,7 +1252,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawWithNotesAdded()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -1274,7 +1274,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawWithColoredNotesAdded()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -1297,7 +1297,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawWithBothColorsAndColoredNotesAdded()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -1324,7 +1324,7 @@ class YUMLMetadataGrapherTest extends TestCase
      */
     public function testDrawWithAnnotationsColorsAndNotes()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\A'
@@ -1343,7 +1343,7 @@ class YUMLMetadataGrapherTest extends TestCase
 
     public function testDrawWithMethods()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\B'

--- a/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/AnnotationParserTest.php
+++ b/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/AnnotationParserTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace OnurbTest\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\AnnotationParser;
 use PHPUnit\Framework\TestCase;
 
@@ -87,60 +87,60 @@ class AnnotationParserTest extends TestCase
 
         $this->parser = new AnnotationParser();
 
-        $this->class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\A'
             ));
 
-        $this->class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class2->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\B'
             ));
 
-        $this->class3 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class3 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class3->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\C'
             ));
 
-        $this->class4 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class4 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class4->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\D'
             ));
 
-        $this->class5 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class5 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class5->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\E'
             ));
 
-        $this->classWithDisplayError = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->classWithDisplayError = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->classWithDisplayError->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\F'
             ));
 
-        $this->class7 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class7 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class7->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\G'
             ));
 
-        $this->class8 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class8 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class8->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\H'
             ));
 
-        $this->class9 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class9 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class9->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\I'
             ));
-        $this->class10 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class10 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class10->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\AnnotationParserTest\\J'
@@ -326,7 +326,7 @@ class AnnotationParserTest extends TestCase
         /**
          * @var ClassMetadata $class
          */
-        $class = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'A'
@@ -342,7 +342,7 @@ class AnnotationParserTest extends TestCase
         /**
          * @var ClassMetadata $class
          */
-        $class = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'A'

--- a/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ClassStoreTest.php
+++ b/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ClassStoreTest.php
@@ -37,32 +37,32 @@ class ClassStoreTest extends TestCase
         require_once('ClassStoreTest/C.php');
         require_once('ClassStoreTest/D.php');
         require_once('ClassStoreTest/E.php');
-        
-        $this->class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+
+        $this->class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\A'
             ));
 
-        $this->class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class2->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\B'
             ));
 
-        $this->class3 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class3 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class3->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\C'
             ));
 
-        $this->class4 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class4 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class4->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\D'
             ));
 
-        $this->class5 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $this->class5 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $this->class5->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YumlMetadataGrapher\\ClassStoreTest\\E'
@@ -98,11 +98,11 @@ class ClassStoreTest extends TestCase
         $this->assertNull($this->classStore->getParent($this->class3));
 
         $this->assertInstanceOf(
-            'Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata',
+            'Doctrine\\Persistence\\Mapping\\ClassMetadata',
             $this->classStore->getParent($this->class4)
         );
         $this->assertInstanceOf(
-            'Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata',
+            'Doctrine\\Persistence\\Mapping\\ClassMetadata',
             $this->classStore->getParent($this->class5)
         );
     }

--- a/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ColorManagerTest.php
+++ b/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/ColorManagerTest.php
@@ -18,7 +18,7 @@
  */
 namespace OnurbTest\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\ColorManager;
 use PHPUnit\Framework\TestCase;
 
@@ -32,10 +32,10 @@ class ColorManagerTest extends TestCase
 {
     public function testDrawColors()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
 
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('Other\\Entity'));
 
         $colors = array(

--- a/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/NotesManagerTest.php
+++ b/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/NotesManagerTest.php
@@ -18,7 +18,7 @@
  */
 namespace OnurbTest\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\NotesManager;
 use PHPUnit\Framework\TestCase;
 
@@ -40,10 +40,10 @@ class NotesManagerTest extends TestCase
     {
         parent::setUp();
 
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
 
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('Other\\Entity'));
 
         $classStore = $this->createMock(

--- a/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator/FieldGeneratorHelperTest.php
+++ b/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGenerator/FieldGeneratorHelperTest.php
@@ -64,7 +64,7 @@ class FieldGeneratorHelperTest extends TestCase
      */
     public function testUniqueField()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -121,7 +121,7 @@ class FieldGeneratorHelperTest extends TestCase
      */
     public function testStringField()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -180,7 +180,7 @@ class FieldGeneratorHelperTest extends TestCase
      */
     public function testDecimalField()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',

--- a/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGeneratorTest.php
+++ b/tests/OnurbTest/Doctrine/ORMMetadataGrapher/YumlMetadataGrapher/StringGeneratorTest.php
@@ -18,7 +18,7 @@
  */
 namespace OnurbTest\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\ClassStore;
 use Onurb\Doctrine\ORMMetadataGrapher\YumlMetadataGrapher\StringGenerator;
 use PHPUnit\Framework\TestCase;
@@ -67,7 +67,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetClassString()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array('a', 'b', 'c')));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -85,7 +85,7 @@ class StringGeneratorTest extends TestCase
 
         $classStore->expects($this->any())->method('getParent')
             ->will($this->returnValue(null));
-        
+
         $stringGenerator = new StringGenerator($classStore);
 
         $this->assertSame('[Simple.Entity|+a;b;c]', $stringGenerator->getClassString($class1));
@@ -96,7 +96,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetClassStringWithParentFieldMatching()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('Extended\\Entity'));
         $class1->expects($this->any())->method('getFieldNames')
             ->will($this->returnValue(array('a', 'b', 'c', 'd', 'e', 'f', 'g')));
@@ -109,7 +109,7 @@ class StringGeneratorTest extends TestCase
             )
         );
 
-        $classParent = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $classParent = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $classParent->expects($this->any())->method('getName')->will($this->returnValue('Parent\\Entity'));
         $classParent->expects($this->any())->method('getFieldNames')->will($this->returnValue(array('d')));
         $classParent->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
@@ -141,7 +141,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testClassStringWithOlderParentFieldsMatching()
     {
-        $class1 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')
             ->will($this->returnValue(
                 'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YUMLMetadataGrapher\\ClassStoreTest\\E'
@@ -157,7 +157,7 @@ class StringGeneratorTest extends TestCase
             )
         );
 
-        $classParent = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $classParent = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $classParent->expects($this->any())->method('getName')->will($this->returnValue(
             'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YUMLMetadataGrapher\\ClassStoreTest\\D'
         ));
@@ -165,7 +165,7 @@ class StringGeneratorTest extends TestCase
         $classParent->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $classParent->expects($this->any())->method('isIdentifier')->will($this->returnValue(false));
 
-        $classOlderParent = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $classOlderParent = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $classOlderParent->expects($this->any())->method('getName')->will($this->returnValue(
             'OnurbTest\\Doctrine\\ORMMetadataGrapher\\YUMLMetadataGrapher\\ClassStoreTest\\A'
         ));
@@ -204,7 +204,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetAssociationString()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -238,7 +238,7 @@ class StringGeneratorTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
@@ -255,7 +255,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetAssociationStringWithUnknownTargetClass()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -293,7 +293,7 @@ class StringGeneratorTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->createMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2 = $this->createMock('Doctrine\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
@@ -311,7 +311,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetAssociationStringWithUnknownTargetClassInverseSide()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -350,7 +350,7 @@ class StringGeneratorTest extends TestCase
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -400,7 +400,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetAssociationMappingWithBidirectionnalOneToOneRelation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -437,7 +437,7 @@ class StringGeneratorTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -486,7 +486,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetAssociationMappingWithBidirectionnalManyToOneRelation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -523,7 +523,7 @@ class StringGeneratorTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -572,7 +572,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetAssociationMappingWithBidirectionnalManyToManyRelation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -609,7 +609,7 @@ class StringGeneratorTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class2 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -658,7 +658,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetClassStringWithFullAttributes()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -735,7 +735,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testGetClassStringWithDecimalFullAttributes()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -811,7 +811,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testClassStringWithShowFieldsBloquedByAnnotation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -890,7 +890,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testClassStringWithShowFieldsForcedByAnnotation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -971,7 +971,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testClassStringWithFieldHiddenByAnnotation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',
@@ -1052,7 +1052,7 @@ class StringGeneratorTest extends TestCase
      */
     public function testClassHideFieldsAnnotation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
+        $class1 = $this->getMockBuilder('Doctrine\\Persistence\\Mapping\\ClassMetadata')
             ->setMethods(array(
                 'getName',
                 'getIdentifier',


### PR DESCRIPTION
Class `Doctrine\Common\Persistence\Mapping\ClassMetadata` no longer exists. It has been replaced with `Doctrine\Persistence\Mapping\ClassMetadata`